### PR TITLE
refactor(index): Shorter code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
-import { Spotify } from "./plugin";
-export = Spotify;
+export { Spotify } from "./plugin";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Spotify } from "./plugin";
+export { Spotify as default } from "./plugin";


### PR DESCRIPTION
Why importing and then exporting when you can just export them directly?